### PR TITLE
put config stuff in correct directory

### DIFF
--- a/lib/generators/s3_multipart/install_generator.rb
+++ b/lib/generators/s3_multipart/install_generator.rb
@@ -11,8 +11,8 @@ module S3Multipart
     end
 
     def create_configuration_files
-      copy_file "aws.yml", "app/config/aws.yml" 
-      copy_file "configuration_initializer.rb", "app/config/initializers/s3_multipart.rb"
+      copy_file "aws.yml", "config/aws.yml"
+      copy_file "configuration_initializer.rb", "config/initializers/s3_multipart.rb"
       route 'mount S3Multipart::Engine => "/s3_multipart"'
     end
 


### PR DESCRIPTION
Right now you're dropping things in `app/config`, which I believe is incorrect. This should fix that and put them in just `config` with everything else.

This lead to a weird bug where we had overridden the gem's initializer in the normal config directory, but there was still a generated one hiding in `app/config/initializers` that was looking for files that didn't exist. This only popped up in the production env.
