### PR TITLE
remove 5MB minimum Javascript check.  <5MB allowed by AWS

### DIFF
--- a/vendor/assets/javascripts/s3_multipart/lib.js
+++ b/vendor/assets/javascripts/s3_multipart/lib.js
@@ -157,12 +157,6 @@ function S3MP(options) {
   }
 
   _.each(files, function(file, key) {
-    if (file.size < 5000000) {
-      return S3MP.onError({name: "FileSizeError", message: "File size is too small"})
-      // This should still work. The multipart API just can't be used b/c Amazon doesn't allow 
-      // multipart file uploads that are less than 5 mb in size.
-    }
-
     var upload = new Upload(file, S3MP, key);
     S3MP.uploadList.push(upload);
     upload.init();


### PR DESCRIPTION
I tested this with files < 5MB in size and they are uploaded successfully to AWS.   I think this must have been an older restriction.   AWS states in [quick facts](http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html) the last part of a multipart upload can be < 5 MB, and perhaps if there is only a single part, it treats it similarly.
